### PR TITLE
Fix/pacman input

### DIFF
--- a/rn/src/components/GamePicker.tsx
+++ b/rn/src/components/GamePicker.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { useRouter } from "expo-router";
+import { usePathname, useRouter } from "expo-router";
 import {
   Platform,
   Pressable,
@@ -14,9 +14,11 @@ import { useTheme } from "../theme-context";
 /** Home game list — keyboard arrows + click to open. */
 export function GamePicker() {
   const router = useRouter();
+  const pathname = usePathname();
   const { typography } = useTheme();
   const pixel = typography.pixelFamily;
   const [selected, setSelected] = useState(0);
+  const onLobby = pathname === "/" || pathname === "";
 
   const openGame = useCallback(
     (index: number) => {
@@ -27,6 +29,7 @@ export function GamePicker() {
   );
 
   useEffect(() => {
+    if (!onLobby) return;
     if (Platform.OS !== "web" || typeof window === "undefined") return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "ArrowDown" || e.key === "s" || e.key === "S") {
@@ -54,7 +57,7 @@ export function GamePicker() {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [openGame, selected]);
+  }, [onLobby, openGame, selected]);
 
   return (
     <View style={styles.stage}>

--- a/rn/src/hooks/usePacmanGame.ts
+++ b/rn/src/hooks/usePacmanGame.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname } from "expo-router";
 import { Platform } from "react-native";
 import {
   getPacmanSnapshot,
@@ -44,6 +45,10 @@ function writeStoredHighScore(value: number) {
 export function usePacmanGame(opts?: {
   onGameOver?: (finalScore: number) => void;
 }) {
+  const pathname = usePathname();
+  const screenActive = pathname === "/games/pacman";
+  const screenActiveRef = useRef(screenActive);
+  screenActiveRef.current = screenActive;
   const [snap, setSnap] = useState<PacmanSnapshot>(() => getPacmanSnapshot());
   const [activeDir, setActiveDir] = useState<Dir | null>(null);
   const phaseRef = useRef<GamePhase>(snap.phase);
@@ -82,27 +87,36 @@ export function usePacmanGame(opts?: {
     }
   }, [sync]);
 
-  // rAF sim; speeds/mouth
+  // One rAF for the screen lifetime. Restarting on phase change leaks a loop
+  // (cleanup cancels the fired frame; that frame still schedules the next).
   useEffect(() => {
-    if (
-            snap.phase !== "playing" &&
-            snap.phase !== "ready" &&
-            snap.phase !== "dying"
-        ) return;
     if (typeof requestAnimationFrame === "undefined") return;
+    let alive = true;
     let raf = 0;
     let last =
       typeof performance !== "undefined" ? performance.now() : Date.now();
     const frame = (now: number) => {
-      const dt = Math.min(0.05, (now - last) / 1000);
-      last = now;
-      tickPacman(dt);
-      sync();
+      if (!alive) return;
+      const phase = phaseRef.current;
+      if (
+        screenActiveRef.current &&
+        (phase === "playing" || phase === "ready" || phase === "dying")
+      ) {
+        const dt = Math.min(0.05, (now - last) / 1000);
+        last = now;
+        tickPacman(dt);
+        sync();
+      } else {
+        last = now;
+      }
       raf = requestAnimationFrame(frame);
     };
     raf = requestAnimationFrame(frame);
-    return () => cancelAnimationFrame(raf);
-  }, [snap.phase, sync]);
+    return () => {
+      alive = false;
+      cancelAnimationFrame(raf);
+    };
+  }, [sync]);
 
   const startGame = useCallback(() => {
     startPacman();
@@ -127,6 +141,7 @@ export function usePacmanGame(opts?: {
   }, [sync]);
 
   useEffect(() => {
+    if (!screenActive) return;
     if (Platform.OS !== "web" || typeof window === "undefined") return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Enter" || e.key === " ") {
@@ -159,7 +174,7 @@ export function usePacmanGame(opts?: {
       window.removeEventListener("keydown", onKeyDown);
       window.removeEventListener("keyup", onKeyUp);
     };
-  }, [sync]);
+  }, [screenActive, sync]);
 
   return {
     ...snap,

--- a/rn/src/hooks/useSnakeGame.ts
+++ b/rn/src/hooks/useSnakeGame.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname } from "expo-router";
 import { Platform } from "react-native";
 import { TICK_MS } from "../game/constants";
 import {
@@ -40,6 +41,10 @@ function writeStoredHighScore(value: number) {
 export function useSnakeGame(opts?: {
   onGameOver?: (finalScore: number) => void;
 }) {
+  const pathname = usePathname();
+  const screenActive = pathname === "/games/snake";
+  const screenActiveRef = useRef(screenActive);
+  screenActiveRef.current = screenActive;
   const [status, setStatus] = useState<GameState>("menu");
   const [snake, setSnake] = useState<Snake | undefined>();
   const [food, setFood] = useState<Point | undefined>();
@@ -109,10 +114,8 @@ export function useSnakeGame(opts?: {
   }, []);
 
   useEffect(() => {
-    if (status !== "playing") return;
-
-    // rAF + accumulator: at most one step per frame so a tab/timer backlog
-    // cannot slam the snake into a wall on the first keypress.
+    if (typeof requestAnimationFrame === "undefined") return;
+    let alive = true;
     let raf = 0;
     const nowMs = () =>
       typeof performance !== "undefined" &&
@@ -122,23 +125,31 @@ export function useSnakeGame(opts?: {
     let last = nowMs();
     let acc = 0;
     const loop = (now: number) => {
-      const dt = Math.min(TICK_MS, now - last);
-      last = now;
-      acc += dt;
-      if (acc >= TICK_MS) {
-        acc -= TICK_MS;
-        drawGame();
-        syncFromWorld();
+      if (!alive) return;
+      if (screenActiveRef.current && statusRef.current === "playing") {
+        const dt = Math.min(TICK_MS, now - last);
+        last = now;
+        acc += dt;
+        if (acc >= TICK_MS) {
+          acc -= TICK_MS;
+          drawGame();
+          syncFromWorld();
+        }
+      } else {
+        last = now;
+        acc = 0;
       }
-      if (getWorld().state === "playing") {
-        raf = requestAnimationFrame(loop);
-      }
+      raf = requestAnimationFrame(loop);
     };
     raf = requestAnimationFrame(loop);
-    return () => cancelAnimationFrame(raf);
-  }, [status, syncFromWorld]);
+    return () => {
+      alive = false;
+      cancelAnimationFrame(raf);
+    };
+  }, [syncFromWorld]);
 
   useEffect(() => {
+    if (!screenActive) return;
     if (Platform.OS !== "web") return;
 
     const keyPressed = (e: KeyboardEvent) => {
@@ -185,7 +196,7 @@ export function useSnakeGame(opts?: {
       window.removeEventListener("keydown", keyPressed);
       window.removeEventListener("keyup", keyReleased);
     };
-  }, [start, setDirection, clearActiveDir]);
+  }, [screenActive, start, setDirection, clearActiveDir]);
 
   return {
     state: status,


### PR DESCRIPTION
- Stop the home game picker from handling keys after leaving `/`. Expo Router keeps that screen mounted, so Right/D/Enter/Space still called `openGame(0)` and pushed `/games/snake` mid Pac-Man.
- Keep a single Pac-Man `requestAnimationFrame` loop for the screen lifetime, with an `alive` flag, so READY/death no longer leaks extra ticks and speeds up the maze.
- Do the same for Snake, and only tick or listen for keys while `/games/pacman` or `/games/snake` is the active route.